### PR TITLE
Update doc install for GN 2.12

### DIFF
--- a/docs/installation-fr.adoc
+++ b/docs/installation-fr.adoc
@@ -44,17 +44,17 @@ Il est nécessaire de gérer les fichiers de configuration, l'installation et la
 
 L'application *_Occtax-mobile_* se chargera alors de récupérer automatiquement sur le serveur GeoNature la dernière version du fichier de configuration des applications et détectera les éventuelles mises à jour disponibles pour l'application.
 
-Pour cela, chargez l'APK de l'application *_Occtax-mobile_* ainsi que son fichier de configuration `settings.json` dans le dossier `$HOME/geonature/backend/static/mobile/occtax` du serveur GeoNature.
+Pour cela, chargez l'APK de l'application *_Occtax-mobile_* ainsi que son fichier de configuration `settings.json` dans le dossier `$HOME/geonature/backend/media/mobile/occtax` du serveur GeoNature.
 
 Dans les commandes ci-dessous, remplacez `x.y.y` par le numéro (tag) de la version (release) utilisée.
 
 * *_Occtax-mobile_* : https://github.com/PnX-SI/gn_mobile_occtax/releases
 
-Sur votre serveur GeoNature, créer le sous-répertoire de l'application mobile *_Occtax-mobile_*.
+Sur votre serveur GeoNature, créez le sous-répertoire de l'application mobile *_Occtax-mobile_*.
 
 [source,shell]
 ----
-cd $HOME/geonature/backend/static/mobile
+cd ~/geonature/backend/media/mobile
 mkdir occtax
 ----
 
@@ -68,7 +68,7 @@ wget https://github.com/PnX-SI/gn_mobile_occtax/releases/download/x.y.z/occtax-y
 
 Créer le fichier de settings `settings.json` en suivant https://github.com/PnX-SI/gn_mobile_occtax#settings[la documentation] en fonction de la configuration de votre serveur GeoNature.
 
-Renseigner ensuite la table `gn_commons.t_mobile_apps` de la base de données.
+Renseigner ensuite la table `gn_commons.t_mobile_apps` directement dans la base de données ou depuis le backoffice du module "Admin" de GeoNature.
 
 Pour trouver la valeur à renseigner dans le champs `version_code`, celui-ci est mentionné dans les releases, ou reportez-vous au fichier suivant en sélectionnant le tag de version où la branche que vous utilisez :
 
@@ -80,14 +80,14 @@ Exemple de contenu de la table `gn_commons.t_mobile_apps` :
 
 [source,csv]
 ----
-1;"OCCTAX";"static/mobile/occtax/occtax-2.0.0-pne-debug.apk";"";"fr.geonature.occtax2";"2555"
+1;"OCCTAX";"occtax/occtax-2.0.0-pne-debug.apk";"";"fr.geonature.occtax2";"2555"
 ----
 
 Le résultat peut être testé en interrogeant directement la route `&lt;URL_GEONATURE&gt;/api/gn_commons/t_mobile_apps` qui est celle utilisée par l'application *_Occtax-mobile_* pour faire les mises à jour.
 
 Installez ensuite l'application *_Occtax-mobile_* sur le terminal mobile.
 
-Récupérer le fichier APK de la version souhaitée dans la fichiers de la release (assets)
+Récupérer le fichier APK de la version souhaitée dans les fichiers de la release (assets)
 
 Lancez l'application *_Occtax-mobile_* et déclarez l'URL de GeoNature et de TaxHub dans sa configuration (paramètres).
 


### PR DESCRIPTION
In GeoNature 2.12.0, media including Occtax-mobile files (APK and settings.json) have been moved to `backend/media/`