### PR TITLE
Allow applicationId customization

### DIFF
--- a/occtax/src/main/AndroidManifest.xml
+++ b/occtax/src/main/AndroidManifest.xml
@@ -78,8 +78,8 @@
             android:name="fr.geonature.commons.data.MainContentProvider"
             android:authorities="${applicationId}.provider"
             android:exported="true"
-            android:readPermission="@string/permission_read"
-            android:writePermission="@string/permission_write" />
+            android:readPermission="${applicationId}.permission.READ"
+            android:writePermission="${applicationId}.permission.WRITE" />
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.file.provider"


### PR DESCRIPTION
This pull request changes the way read and write permissions are named, in order to use the `applicationId` defined for the app in `occtax/build.gradle` file. This makes more convenient for developpers to create an application that can be installed and used alongside other Occtax applications.

This PR works together with the [PR#47](https://github.com/PnX-SI/gn_mobile_core/pull/47) in gn_mobile_core.