### PR TITLE
fix(#268): add security on media file name

### DIFF
--- a/occtax/src/main/java/fr/geonature/occtax/ui/input/counting/TakePhotoLifecycleObserver.kt
+++ b/occtax/src/main/java/fr/geonature/occtax/ui/input/counting/TakePhotoLifecycleObserver.kt
@@ -110,7 +110,7 @@ class TakePhotoLifecycleObserver(
 
     private fun asFile(uri: Uri): File {
         val filename = (uri.lastPathSegment ?: "${Date().time}").let {
-            "${it.substringBeforeLast(".")}.jpg"
+            "${it.substringBeforeLast(".").substringAfterLast("/")}.jpg"
         }
 
         if (!File(


### PR DESCRIPTION
This pull request changes the way media files uploaded from the gallery are set. 

Normally, the method `lastPathSegment` called from an URI object retrieves the last segment from the path, that is, the file name itself with extension. However, users reports showed that on certain phones (apparently Xiaomi), this method returns the full file path instead, resulting in subsequent errors when uploading medias from gallery.

We add a `substringAfterLast("/")` on the `uri.lastPathSegment` to make sure that only the file name is used.

Tested on two Xiaomi phones that experienced the bug : it seems fix
plus one other phone : no regression.

Fixes bug #268 